### PR TITLE
fix(init): Bool return in init function

### DIFF
--- a/Muca.cpp
+++ b/Muca.cpp
@@ -275,6 +275,7 @@ bool Muca::init(bool interrupt) {
     #endif   
   }
   setRegister(0xA7,0x04); // Set autocalibration
+  return 0;  // necessary to avoid error
 }
 
 


### PR DESCRIPTION
Hello, I fixed a bug in Muca.init.
dum error but the function has bool signature but didn't always return a bool.

You'r welcome my brother.